### PR TITLE
App requires development and test gems.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ RUN apk --no-cache add \
 COPY Gemfile Gemfile.lock ./
 
 # Install bundler version which created the lock file and configure it
-RUN gem install bundler -v $(awk '/^BUNDLED WITH/ { getline; print $1; exit }' Gemfile.lock) \
-    && bundle config --global without development:test
+RUN gem install bundler -v $(awk '/^BUNDLED WITH/ { getline; print $1; exit }' Gemfile.lock)
 
 # Install build-dependencies, then install gems, subsequently removing build-dependencies
 RUN apk --no-cache add --virtual build-deps build-base postgresql-dev imagemagick-dev ghostscript-dev \


### PR DESCRIPTION
When starting the app in ECS, we encountered.
```
Could not find pry-byebug-3.9.0, rspec-rails-5.0.1, dotenv-rails-2.7.6, web-console-4.0.4, spring-2.1.1, spring-commands-rspec-1.0.4, capybara-3.33.0, selenium-webdriver-3.142.7, webdrivers-4.4.1, byebug-11.1.3, pry-0.13.1, rspec-core-3.10.1, rspec-expectations-3.10.1, rspec-mocks-3.10.2, rspec-support-3.10.2, dotenv-2.7.6, bindex-0.8.1, addressable-2.8.1, regexp_parser-1.8.1, xpath-3.2.0, childprocess-3.0.0, rubyzip-2.3.0, coderay-1.1.3, diff-lcs-1.4.4, public_suffix-5.0.0 in any of the sources
```